### PR TITLE
Fix a bug with digitTextSize

### DIFF
--- a/pinentry/src/main/java/me/philio/pinentry/PinEntryView.java
+++ b/pinentry/src/main/java/me/philio/pinentry/PinEntryView.java
@@ -332,7 +332,7 @@ public class PinEntryView extends ViewGroup {
             digitView.setHeight(digitHeight);
             digitView.setBackgroundResource(digitBackground);
             digitView.setTextColor(digitTextColor);
-            digitView.setTextSize(digitTextSize);
+            digitView.setTextSize(TypedValue.COMPLEX_UNIT_PX, digitTextSize);
             digitView.setGravity(Gravity.CENTER);
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                 digitView.setElevation(digitElevation);


### PR DESCRIPTION
On the PinEntryView builder digitTextSize gets its value from he method
array.getDimensionPixelSize, which returns an int that represents the
dimension in PIXELS.
After that on the addViews method this value is fed to the
TextView.setTextSize(float) method that expects a value in DENSITY
INDEPENDENT PIXELS. This causes the digits to look different on each
screen based on that screen's resolution (higher resolution will show
bigger numbers).
I fixed this issue by using TextView.setTextSize(int, float) instead
and setting the unit of the dimension to be PX instead of DP
