### PR TITLE
Fix a bug when using PinEntryView.setText()

### DIFF
--- a/pinentry/src/main/java/me/philio/pinentry/PinEntryView.java
+++ b/pinentry/src/main/java/me/philio/pinentry/PinEntryView.java
@@ -304,6 +304,7 @@ public class PinEntryView extends ViewGroup {
             text = text.subSequence(0, digits);
         }
         editText.setText(text);
+        editText.setSelection(text.length());
     }
 
     /**


### PR DESCRIPTION
After using PinEntryView.setText() was not possible to delete pin values
